### PR TITLE
ADD: requirements for running Neurosimo speech mapping experiment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,11 +103,20 @@ services:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - ROS_DOMAIN_ID
       - ROS_AUTOMATIC_DISCOVERY_RANGE
+      - DISPLAY=${DISPLAY}
     volumes:
       - "$PROJECTS_ROOT:/app/projects"
       - '/etc/localtime:/etc/localtime:ro'
       - '/etc/timezone:/etc/timezone:ro'
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    devices:
+      - /dev/video0:/dev/video0
+      - /dev/snd:/dev/snd
+    group_add:
+      - video
+      - audio
     network_mode: host
+    privileged: true
     profiles:
       - non-gpu
 
@@ -130,11 +139,20 @@ services:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - ROS_DOMAIN_ID
       - ROS_AUTOMATIC_DISCOVERY_RANGE
+      - DISPLAY=${DISPLAY}
     volumes:
       - "$PROJECTS_ROOT:/app/projects"
       - '/etc/localtime:/etc/localtime:ro'
       - '/etc/timezone:/etc/timezone:ro'
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    devices:
+      - /dev/video0:/dev/video0
+      - /dev/snd:/dev/snd
+    group_add:
+      - video
+      - audio
     network_mode: host
+    privileged: true
     deploy:
       resources:
         reservations:

--- a/src/decider/Dockerfile
+++ b/src/decider/Dockerfile
@@ -24,6 +24,18 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     dos2unix \
     wget \
+    libgl1 \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender1 \
+    libxrandr2 \
+    v4l-utils \
+    libasound2t64 \
+    libasound2-dev \
+    portaudio19-dev \
+    libportaudiocpp0 \
+    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up CUDA environment variables.

--- a/src/decider/requirements/science.txt
+++ b/src/decider/requirements/science.txt
@@ -17,3 +17,7 @@ joblib==1.5.3
 einops==0.8.2
 spectrum==0.9.0
 tensorflow==2.21.0
+opencv-python-headless==4.13.0.92
+mss==10.1.0
+sounddevice==0.5.5
+soundfile==0.13.1


### PR DESCRIPTION
This PR adds the required dependencies to enable webcam, audio, and screen recording support in Decider for the Neurosimo speech mapping experiment workflow.

With these additions, it is now possible to record webcam video, microphone audio, and screen activity directly from Decider. This enables using Presenter to provide visual stimuli to the subject and trigger TMS pulses based on those stimuli, while recording the session for later analysis of the subject’s responses relative to stimulation timing.